### PR TITLE
enable query by series on episodes

### DIFF
--- a/database.rules.bolt
+++ b/database.rules.bolt
@@ -64,6 +64,7 @@ type Episode{
   create() { auth != null }
   update() { auth != null }
   validate() { isSnakeCase(key()) }
+  index() {['number', 'series']}
   number: Number
   series: SeriesID
   title : String


### PR DESCRIPTION
ルールのepisodes直下に↓を入れると、クエリでフィルタするのに使えるようなのでいれたいですが、boltの書き方はわかりません😉

```
 ".indexOn": ["number", "series"],
```

このときのSwift例、(queryEqualはorderに付随する機能なので、orderを前置しないといけないらしい・・?)

```swift
Database.shared.ref.child("episodes").queryOrdered(byChild: "series").queryEqual(toValue: "pripara").observe(.value)
```