### PR TITLE
index should be placed in path in bolt

### DIFF
--- a/database.rules.bolt
+++ b/database.rules.bolt
@@ -60,11 +60,14 @@ type Series{
 
 path /episodes/{episode_key} is Episode;
 
+path /episodes is Episode[] {
+  index() {['number', 'series']}
+}
+
 type Episode{
   create() { auth != null }
   update() { auth != null }
   validate() { isSnakeCase(key()) }
-  index() {['number', 'series']}
   number: Number
   series: SeriesID
   title : String


### PR DESCRIPTION
indexOn指定だめでした

<img width="137" alt="image" src="https://user-images.githubusercontent.com/11156/40276806-6c28584c-5c4e-11e8-9dc7-b676759e3bf6.png">


indexはpathに書かないといけないらしい...すると `/episodes/{episode_key}` と重複して `$key7` も生成されるようになるが...生成物だからOK??