### PR TITLE
Fix: boltから生成されたルールで$...keyが二つになるとデプロイできない

### DIFF
--- a/database.rules.bolt
+++ b/database.rules.bolt
@@ -58,9 +58,7 @@ type Series{
   episodes : Map<EpisodeID, True>
 }
 
-path /episodes/{episode_key} is Episode;
-
-path /episodes is Episode[] {
+path /episodes/{episode_key} is Episode {
   index() {['number', 'series']}
 }
 


### PR DESCRIPTION
> fix error: Cannot have multiple default rules ('$episode_key' and '$key7')

<img width="209" alt="image" src="https://user-images.githubusercontent.com/11156/40277034-0915980a-5c53-11e8-97d1-7ebc9d438ab4.png">

`/episodes` をまとめてみましたが、はたしてこれで `/episodes` で効くんですかね‥?