### PR TITLE
indexの位置を/episodes直下に上げる(pathの数自体を増やさずに)

### DIFF
--- a/database.rules.bolt
+++ b/database.rules.bolt
@@ -58,8 +58,9 @@ type Series{
   episodes : Map<EpisodeID, True>
 }
 
-path /episodes/{episode_key} is Episode {
+path /episodes {
   index() {['number', 'series']}
+  /{episode_key} is Episode;
 }
 
 type Episode{


### PR DESCRIPTION

<img width="429" alt="image" src="https://user-images.githubusercontent.com/11156/40277236-83de2dce-5c56-11e8-8fd7-612cdafb21ec.png">


https://github.com/firebase/bolt/blob/032e90e784c26b8fbc79540d4b3b68512f2663e9/samples/userdoc.bolt